### PR TITLE
Reduce false positives

### DIFF
--- a/scanner/detectors/boolean_based.py
+++ b/scanner/detectors/boolean_based.py
@@ -1,5 +1,5 @@
 import urllib.parse
-from ..utils import send_request, evasion_variants
+from ..utils import send_request, evasion_variants, is_response_stable
 
 _CACHE: dict[tuple, str] = {}
 
@@ -134,6 +134,15 @@ def test_parameter(
         except Exception as e:
             baseline_body = str(e)
     baseline_len = len(baseline_body)
+    stable = is_response_stable(
+        url,
+        method=method,
+        data=data if method.lower() == "post" else None,
+        cookies=cookies,
+        headers=headers,
+        attempts=2,
+        threshold=0.2,
+    )
 
     results = []
     for p_true, p_false in zip(PAYLOADS_TRUE, PAYLOADS_FALSE):
@@ -259,9 +268,9 @@ def test_parameter(
             len_true = len(body_true)
             len_false = len(body_false)
             vulnerable = (
-                len_true != len_false and (
-                    len_true == baseline_len or len_false == baseline_len
-                )
+                len_true != len_false
+                and (len_true == baseline_len or len_false == baseline_len)
+                and stable
             )
             results.append(
                 {

--- a/scanner/detectors/union_based.py
+++ b/scanner/detectors/union_based.py
@@ -1,6 +1,6 @@
 import re
 import urllib.parse
-from ..utils import send_request, evasion_variants
+from ..utils import send_request, evasion_variants, is_response_stable
 
 from .. import diff
 
@@ -141,6 +141,16 @@ def test_parameter(
         except Exception as e:
             baseline_body = str(e)
 
+    stable = is_response_stable(
+        url,
+        method=method,
+        data=data if method.lower() == "post" else None,
+        cookies=cookies,
+        headers=headers,
+        attempts=2,
+        threshold=0.2,
+    )
+
     results = []
     for payload in PAYLOADS:
         for variant in evasion_variants(payload):
@@ -212,7 +222,7 @@ def test_parameter(
 
             error = any(p.search(body) for p in ERROR_PATTERNS)
             diff_found = diff.is_significant_diff(baseline_body, body)
-            vulnerable = diff_found and not error
+            vulnerable = diff_found and not error and stable
             results.append(
                 {
                     'url': new_url,


### PR DESCRIPTION
## Summary
- add helper functions to check response stability and measure response timing
- use these helpers in union, boolean, and time based detection modules to ignore unstable pages

## Testing
- `python -m unittest`